### PR TITLE
Don't create an Enum type for views sort it it is empty.

### DIFF
--- a/src/Plugin/Deriver/Enums/ViewSortByDeriver.php
+++ b/src/Plugin/Deriver/Enums/ViewSortByDeriver.php
@@ -34,11 +34,13 @@ class ViewSortByDeriver extends ViewDeriverBase {
           return $sort['exposed'];
         }));
 
-        $id = implode('-', [$viewId, $displayId, 'view']);
-        $this->derivatives["$viewId-$displayId"] = [
-          'name' => StringHelper::camelCase($id, 'sort', 'by'),
-          'values' => $sorts,
-        ] + $basePluginDefinition;
+        if (!empty($sorts)) {
+          $id = implode('-', [$viewId, $displayId, 'view']);
+          $this->derivatives["$viewId-$displayId"] = [
+            'name' => StringHelper::camelCase($id, 'sort', 'by'),
+            'values' => $sorts,
+          ] + $basePluginDefinition;
+        }
       }
     }
 


### PR DESCRIPTION
Stopping ViewSortByDeriver from creating an empty ENUM type, since this would cause an error in GraphQL explore. 


```
Uncaught Error: .......ViewSortBy values must be an object with value names as keys.
```

```
"kind":"ENUM",
"name":"....ViewSortBy",
"description":"",
"fields":null,
"inputFields":null,
"interfaces":null,
"enumValues":[
],
"possibleTypes":null
```
