### PR TITLE
Invalid call to EntityTypeManager::getTranslationFromContext

### DIFF
--- a/src/Plugin/views/row/GraphQLEntityRow.php
+++ b/src/Plugin/views/row/GraphQLEntityRow.php
@@ -3,7 +3,7 @@
 namespace Drupal\graphql_views\Plugin\views\row;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Entity\Plugin\DataType\EntityAdapter;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\views\Entity\Render\EntityTranslationRenderTrait;
@@ -44,7 +44,7 @@ class GraphQLEntityRow extends RowPluginBase {
    *
    * @var \Drupal\Core\Entity\EntityManagerInterface
    */
-  protected $entityTypeManager;
+  protected $entityManager;
 
   /**
    * The language manager.
@@ -56,15 +56,15 @@ class GraphQLEntityRow extends RowPluginBase {
   /**
    * {@inheritdoc}
    *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entityManager
    *   The entity type manager.
    * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
    *   The language manager.
    */
-  public function __construct(array $configuration, $pluginId, $pluginDefinition, EntityTypeManagerInterface $entityTypeManager, LanguageManagerInterface $languageManager) {
+  public function __construct(array $configuration, $pluginId, $pluginDefinition, EntityManagerInterface $entityManager, LanguageManagerInterface $languageManager) {
     parent::__construct($configuration, $pluginId, $pluginDefinition);
 
-    $this->entityTypeManager = $entityTypeManager;
+    $this->entityManager = $entityManager;
     $this->languageManager = $languageManager;
   }
 
@@ -76,7 +76,7 @@ class GraphQLEntityRow extends RowPluginBase {
       $configuration,
       $pluginId,
       $pluginDefinition,
-      $container->get('entity_type.manager'),
+      $container->get('entity.manager'),
       $container->get('language_manager')
     );
   }
@@ -118,7 +118,7 @@ class GraphQLEntityRow extends RowPluginBase {
    * {@inheritdoc}
    */
   protected function getEntityManager() {
-    return $this->entityTypeManager;
+    return $this->entityManager;
   }
 
   /**


### PR DESCRIPTION
On translated content, call to EntityTypeManager that is not injected in GraphQLEntityRow

I've translated content (no filter), I set up a very simple views:

```
query test {
  graphqlViewsTestGraphql1View {
    results {
      entityLabel
    }
  }
}
```

I got this error:

```
Error: Call to undefined method Drupal\Core\Entity\EntityTypeManager::getTranslationFromContext() in Drupal\graphql_views\Plugin\views\row\GraphQLEntityRow->getEntityTranslation() (line 77 of /var/www/project/web/core/modules/views/src/Entity/Render/EntityTranslationRenderTrait.php) 
#0 /var/www/project/web/modules/contrib/graphql_views/src/Plugin/views/row/GraphQLEntityRow.php(89):
```

GraphQLEntityRow use the trait EntityTranslationRenderTrait that make use of `$this->getEntityManager` that is supposed to be an EntityManager. But this is a EntityTypeManager that is passed and this class does not implement getTranslationFromContext. 

Furthermore, EntityManager::getTranslationFromContext is deprecated in favor of EntityRepository. I think this is the reason behind the use of EntityTypeManager (used for entityManager->getDefinition in EntityTranslationRenderTrait L52). 

But as we depends on EntityTranslationRenderTrait that use $this->getEntityManager for multiple cases (EntityTypeManager / EntityRepository), I think we can't get rid of the use of the deprecated EntityManager.