### PR TITLE
Allow to explicitly attach to an entity type and / or its bundles.

### DIFF
--- a/graphql_views.services.yml
+++ b/graphql_views.services.yml
@@ -1,0 +1,4 @@
+services:
+  graphql_views.token_handler:
+    class: Drupal\graphql_views\TokenHandler
+    arguments: ['@token']

--- a/src/Plugin/Deriver/Fields/ViewDeriver.php
+++ b/src/Plugin/Deriver/Fields/ViewDeriver.php
@@ -3,7 +3,9 @@
 namespace Drupal\graphql_views\Plugin\Deriver\Fields;
 
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Drupal\graphql\Utility\StringHelper;
 use Drupal\graphql_views\Plugin\Deriver\ViewDeriverBase;
+use Drupal\views\Plugin\views\display\DisplayPluginInterface;
 use Drupal\views\Views;
 
 /**
@@ -35,7 +37,7 @@ class ViewDeriver extends ViewDeriverBase implements ContainerDeriverInterface {
         $arguments += $this->getPagerArguments($display);
         $arguments += $this->getSortArguments($display, $id);
         $arguments += $this->getFilterArguments($display, $id);
-        $types = $this->getTypes($info);
+        $types = $this->getTypes($display, $info);
 
         $this->derivatives[$id] = [
           'id' => $id,

--- a/src/Plugin/views/display/GraphQL.php
+++ b/src/Plugin/views/display/GraphQL.php
@@ -338,6 +338,7 @@ class GraphQL extends DisplayPluginBase {
         $form['token']['default_argument'] = [
           '#title' => $this->t('Arguments'),
           '#type' => 'textfield',
+          '#maxlength' => 1024,
           '#default_value' => $this->getOption('default_argument'),
           '#description' => $this->t('You may use token replacement to provide arguments based on the current entity. Separate arguments with "/".'),
         ];
@@ -354,6 +355,7 @@ class GraphQL extends DisplayPluginBase {
           $form['token']['browser'] = [
             '#theme' => 'token_tree_link',
             '#token_types' => $token_types,
+            '#recursion_limit' => 5,
             '#global_types' => TRUE,
             '#show_nested' => FALSE,
           ];
@@ -389,6 +391,7 @@ class GraphQL extends DisplayPluginBase {
         $form['token']['default_limit'] = [
           '#title' => $this->t('Limit'),
           '#type' => 'textfield',
+          '#maxlength' => 1024,
           '#default_value' => $this->getOption('default_limit'),
           '#description' => $this->t('You may use token replacement to provide the limit based on the current entity.'),
         ];
@@ -405,6 +408,7 @@ class GraphQL extends DisplayPluginBase {
           $form['token']['browser'] = [
             '#theme' => 'token_tree_link',
             '#token_types' => $token_types,
+            '#recursion_limit' => 5,
             '#global_types' => TRUE,
             '#show_nested' => FALSE,
           ];

--- a/src/TokenHandler.php
+++ b/src/TokenHandler.php
@@ -56,7 +56,7 @@ class TokenHandler {
     if (empty($args)) {
       return [];
     }
-    $args = $this->token->replace($args, [$type => $object], ['sanitize' => FALSE, 'clear' => TRUE]);
+    $args = $this->token->replace($args, [$type => $object], ['sanitize' => FALSE, 'clear' => FALSE]);
     return explode('/', $args);
   }
 

--- a/src/TokenHandler.php
+++ b/src/TokenHandler.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Shamelessly stolen from: https://git.drupalcode.org/project/eva/blob/8.x-2.x/src/TokenHandler.php
+ */
+namespace Drupal\graphql_views;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Utility\Token;
+
+/**
+ * Token handling service.
+ */
+class TokenHandler {
+
+  /**
+   * The token service.
+   *
+   * @var \Drupal\Core\Utility\Token
+   */
+  protected $token;
+
+  /**
+   * Inject token dependencies.
+   *
+   * @param \Drupal\Core\Utility\Token $token
+   *   The token service.
+   */
+  public function __construct(Token $token) {
+    $this->token = $token;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('token')
+    );
+  }
+
+  /**
+   * Get view arguments array from string that contains tokens.
+   *
+   * @param string $string
+   *   The token string defined by the view.
+   * @param string $type
+   *   The token type.
+   * @param object $object
+   *   The object being used for replacement data (typically a node).
+   *
+   * @return array
+   *   An array of argument values.
+   */
+  public function getArgumentsFromTokenString($string, $type, $object) {
+    $args = trim($string);
+    if (empty($args)) {
+      return [];
+    }
+    $args = $this->token->replace($args, [$type => $object], ['sanitize' => FALSE, 'clear' => TRUE]);
+    return explode('/', $args);
+  }
+
+}

--- a/src/ViewDeriverHelperTrait.php
+++ b/src/ViewDeriverHelperTrait.php
@@ -117,7 +117,17 @@ trait ViewDeriverHelperTrait {
    * @return array
    *   An array of additional types the view can be embedded in.
    */
-  protected function getTypes(array $arguments, array $types = ['Root']) {
+  protected function getTypes(DisplayPluginInterface $display, array $arguments, array $types = ['Root']) {
+
+    if (($entity_type = $display->getOption('entity_type'))) {
+      $types = array_merge($types, [StringHelper::camelCase($entity_type)]);
+
+      if (($bundles = $display->getOption('bundles'))) {
+        $types = array_merge($types, array_map(function ($bundle) use ($entity_type) {
+          return StringHelper::camelCase($entity_type, $bundle);
+        }, $bundles));
+      }
+    }
 
     if (empty($arguments)) {
       return $types;


### PR DESCRIPTION
It would be nice if we could extend that automatic detection of "relations" using views arguments to allow to actually configure where a view is attached.
This basically is the [EVA](https://www.drupal.org/project/eva) approach for GraphQL and quite some code has been borrowed from EVA to create this change.